### PR TITLE
support added for postorder tree traversal merge algorithm

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,20 +19,20 @@ And then execute:
 Or install it yourself as:
 
     $ gem install yaml_extend
-    
+
 ## Common information
 
 It is possible to build inheritance trees like:
 ```
-     defaults.yml   
-  ________\_________    
-  \        \        \                         
- dev.yml  int.yml  prod.yml                   
+     defaults.yml
+  ________\_________
+  \        \        \
+ dev.yml  int.yml  prod.yml
 ```
 or like this:
 ```
-default.yml   english.yml          default.yml   german.yml       
-         \    /                             \    /                
+default.yml   english.yml          default.yml   german.yml
+         \    /                             \    /
           uk.yml                            de.yml
                                               |
                                             at.yml
@@ -40,7 +40,9 @@ default.yml   english.yml          default.yml   german.yml
 
 A file can inherit from as many as you want. Trees can be nested as deep as you want.
 
-YAML files are deep merged, the latest specified child file overwrites the former ones.
+YAML files are deep merged. Two methods are supported:
+- :breadthfirst: the latest specified child file overwrites the former ones, uses deep_merge
+- :postorder   : the tree is traversed in a postorder fashion, where the newer node gets merged into the existing merge, uses deep_merge!
 Array values are merged as well by default. You can specifiy this with the 3rd Parameter.
 
 The files to inherit from are specified by the key 'extends:' in the YAML file.
@@ -62,7 +64,7 @@ Given the following both files are defined:
 extends: 'super.yml'
 data:
     name: 'Mr. Superman'
-    age: 134    
+    age: 134
     favorites:
         - 'Raspberrys'
 ```
@@ -151,12 +153,13 @@ config = YAML.ext_load_file 'custom2.yml', ['options','extend_file']
 ```
 
 ## Documentation
-YAML#ext_load_file(yaml_path, inheritance_key='extends', extend_existing_arrays=true, config = {})
+YAML#ext_load_file(yaml_path, inheritance_key='extends', extend_existing_arrays=true, config = {}, tree_traversal: :breadthfirst))
 
 - *yaml_path* relative or absolute path to yaml file to inherit from
 - *inheritance_key* you can overwrite the default key, if you use the default 'extends' already as part of your configuration. The inheritance_key is NOT included, that means it will be deleted, in the final merged file. Default: 'extends'
 - *extend_existing_arrays* Extends existing arrays in yaml structure instead of replacing them. Default: true
 - *config* only intended to be used by the method itself due recursive algorithm
+- *tree_traversal* :breadthfirst or :postorder. Default: :breadthfirst
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -153,12 +153,13 @@ config = YAML.ext_load_file 'custom2.yml', ['options','extend_file']
 ```
 
 ## Documentation
-YAML#ext_load_file(yaml_path, inheritance_key='extends', extend_existing_arrays=true, config = {}, tree_traversal: :breadthfirst))
+YAML#ext_load_file(yaml_path, inheritance_key='extends', extend_existing_arrays=true, config = {}, files: [], tree_traversal: :breadthfirst))
 
 - *yaml_path* relative or absolute path to yaml file to inherit from
 - *inheritance_key* you can overwrite the default key, if you use the default 'extends' already as part of your configuration. The inheritance_key is NOT included, that means it will be deleted, in the final merged file. Default: 'extends'
 - *extend_existing_arrays* Extends existing arrays in yaml structure instead of replacing them. Default: true
 - *config* only intended to be used by the method itself due recursive algorithm
+- *files* encountered files will be appended to this list
 - *tree_traversal* :breadthfirst or :postorder. Default: :breadthfirst
 
 ## Contributing

--- a/lib/yaml_extend.rb
+++ b/lib/yaml_extend.rb
@@ -56,7 +56,7 @@ module YAML
     # the original code probably could also easily fit in this scheme now, but I did not want to touch the original code
     if tree_traversal==:postorder
       tree, f = build_tree yaml_path, inheritance_key
-      files << f
+      files.push(*f)
       tree.postordered_each do |node|
         merged_children_config={}
         node.children.concat([node]).each do |child|

--- a/lib/yaml_extend.rb
+++ b/lib/yaml_extend.rb
@@ -1,7 +1,8 @@
-require 'yaml_extend/version'
+require_relative 'yaml_extend/version'
 
 require 'yaml'
 require 'deep_merge/rails_compat'
+require 'tree'
 
 require_relative 'yaml_extend/yaml_extend_helper'
 
@@ -35,43 +36,59 @@ module YAML
     @@ext_load_key = nil
   end
   #
-  # Extended variant of the #load_file method by providing the 
+  # Extended variant of the #load_file method by providing the
   # ability to inherit from other YAML file(s)
   #
   # @param yaml_path [String] the path to the yaml file to be loaded
   # @param inheritance_key [String|Array] The key used in the yaml file to extend from another YAML file. Use an Array if you want to use a tree structure key like "options.extends" => ['options','extends']
   # @param extend_existing_arrays [Boolean] extend existing arrays instead of replacing them
+  # @param tree_traversal [:breadthfirst,:postorder] merge order sequence
   # @param config [Hash] a hash to be merged into the result, usually only recursivly called by the method itself
   #
-  # @return [Hash] the resulting yaml config 
+  # @return [Hash] the resulting yaml config
   #
-  def self.ext_load_file(yaml_path, inheritance_key=nil, extend_existing_arrays=true, config = {})
+  def self.ext_load_file(yaml_path, inheritance_key=nil, extend_existing_arrays=true, config = {}, tree_traversal: :breadthfirst)
     if inheritance_key.nil?
       inheritance_key = @@ext_load_key || DEFAULT_INHERITANCE_KEY
     end
-    total_config ||= {}
-    yaml_path = YAML.make_absolute_path yaml_path
-    super_config = YamlExtendHelper.encode_booleans YAML.load_file(File.open(yaml_path))
-    super_inheritance_files = yaml_value_by_key inheritance_key, super_config
-    delete_yaml_key inheritance_key, super_config # we don't merge the super inheritance keys into the base yaml
-    merged_config = config.clone.deeper_merge(super_config, extend_existing_arrays: extend_existing_arrays)
-    if super_inheritance_files && super_inheritance_files != ''
-      super_inheritance_files = [super_inheritance_files] unless super_inheritance_files.is_a? Array # we support strings as well as arrays of type string to extend from
-      super_inheritance_files.each_with_index do |super_inheritance_file, index|
-        super_config_path = File.dirname(yaml_path) + '/' + super_inheritance_file
-        total_config = YamlExtendHelper.encode_booleans YAML.ext_load_file(super_config_path, inheritance_key, extend_existing_arrays, total_config.deeper_merge(merged_config, extend_existing_arrays: extend_existing_arrays))
+    raise "unknown tree_traversal option #{tree_traversal}" unless [:breadthfirst, :postorder].include? tree_traversal
+    # the original code probably could also easily fit in this scheme now, but I did not want to touch the original code
+    if tree_traversal==:postorder
+      tree = build_tree yaml_path, inheritance_key
+      tree.postordered_each do |node|
+        merged_children_config={}
+        node.children.concat([node]).each do |child|
+          new_config = child.content
+          merged_children_config.deeper_merge!(new_config, extend_existing_arrays: extend_existing_arrays)
+        end
+        node.content=merged_children_config
       end
-      YamlExtendHelper.decode_booleans total_config
+      YamlExtendHelper.decode_booleans tree.root.content
     else
-      delete_yaml_key inheritance_key, merged_config
-      YamlExtendHelper.decode_booleans merged_config
+      total_config ||= {}
+      yaml_path = YAML.make_absolute_path yaml_path
+      super_config = YamlExtendHelper.encode_booleans YAML.load_file(File.open(yaml_path))
+      super_inheritance_files = yaml_value_by_key inheritance_key, super_config
+      delete_yaml_key inheritance_key, super_config # we don't merge the super inheritance keys into the base yaml
+      merged_config = config.clone.deeper_merge(super_config, extend_existing_arrays: extend_existing_arrays)
+      if super_inheritance_files && super_inheritance_files != ''
+        super_inheritance_files = [super_inheritance_files] unless super_inheritance_files.is_a? Array # we support strings as well as arrays of type string to extend from
+        super_inheritance_files.each_with_index do |super_inheritance_file, index|
+          super_config_path = File.dirname(yaml_path) + '/' + super_inheritance_file
+          total_config = YamlExtendHelper.encode_booleans YAML.ext_load_file(super_config_path, inheritance_key, extend_existing_arrays, total_config.deeper_merge(merged_config, extend_existing_arrays: extend_existing_arrays), load_order_super2derived: load_order_super2derived)
+        end
+        YamlExtendHelper.decode_booleans total_config
+      else
+        delete_yaml_key inheritance_key, merged_config
+        YamlExtendHelper.decode_booleans merged_config
+      end
     end
   end
 
   private
 
-  # some logic to ensure absolute file inheritance as well as 
-  # relative file inheritance in yaml files  
+  # some logic to ensure absolute file inheritance as well as
+  # relative file inheritance in yaml files
   def self.make_absolute_path(file_path)
     private_class_method
     return file_path if YAML.absolute_path?(file_path) && File.exist?(file_path)
@@ -125,6 +142,23 @@ module YAML
       end
     end
     last_ref.delete key.last unless last_ref.nil?
+  end
+
+  def self.build_tree(yaml_path, inheritance_key, tree = nil)
+    yaml_path = YAML.make_absolute_path yaml_path
+    node_config = YAML.load_file(File.open(yaml_path))
+    children = yaml_value_by_key inheritance_key, node_config
+    delete_yaml_key inheritance_key, node_config  # this info will be put in the tree
+    node = Tree::TreeNode.new yaml_path, node_config
+    if tree.nil? then tree = node else tree << node end
+    if children && children != ''
+      children = [children] unless children.is_a? Array # we support strings as well as arrays of type string to extend from
+      children.each_with_index do |child, index|
+        child_path = File.dirname(yaml_path) + '/' + child
+        YAML.build_tree(child_path, inheritance_key, node)
+      end
+    end
+    return tree
   end
 
 end

--- a/lib/yaml_extend.rb
+++ b/lib/yaml_extend.rb
@@ -75,7 +75,7 @@ module YAML
         super_inheritance_files = [super_inheritance_files] unless super_inheritance_files.is_a? Array # we support strings as well as arrays of type string to extend from
         super_inheritance_files.each_with_index do |super_inheritance_file, index|
           super_config_path = File.dirname(yaml_path) + '/' + super_inheritance_file
-          total_config = YamlExtendHelper.encode_booleans YAML.ext_load_file(super_config_path, inheritance_key, extend_existing_arrays, total_config.deeper_merge(merged_config, extend_existing_arrays: extend_existing_arrays), load_order_super2derived: load_order_super2derived)
+          total_config = YamlExtendHelper.encode_booleans YAML.ext_load_file(super_config_path, inheritance_key, extend_existing_arrays, total_config.deeper_merge(merged_config, extend_existing_arrays: extend_existing_arrays))
         end
         YamlExtendHelper.decode_booleans total_config
       else

--- a/test/a0.yaml
+++ b/test/a0.yaml
@@ -1,0 +1,3 @@
+files:
+- a0
+value: 0

--- a/test/a1.yaml
+++ b/test/a1.yaml
@@ -1,0 +1,4 @@
+extends: a0.yaml
+files:
+- a1
+value: 10

--- a/test/b0.yaml
+++ b/test/b0.yaml
@@ -1,0 +1,3 @@
+files:
+- b0
+value: 1

--- a/test/b1.yaml
+++ b/test/b1.yaml
@@ -1,0 +1,4 @@
+extends: b0.yaml
+files:
+- b1
+value: 11

--- a/test/base.yaml
+++ b/test/base.yaml
@@ -1,0 +1,8 @@
+# base.yaml
+---
+blockX:
+- playground:
+    macros:
+      M_BASE: ja
+      M_REPLACE: to_be_replaced
+...

--- a/test/c0.yaml
+++ b/test/c0.yaml
@@ -1,0 +1,3 @@
+files:
+- c0
+value: 2

--- a/test/c1.yaml
+++ b/test/c1.yaml
@@ -1,0 +1,4 @@
+extends: c0.yaml
+files:
+- c1
+value: 12

--- a/test/d0.yaml
+++ b/test/d0.yaml
@@ -1,0 +1,7 @@
+extends:
+- a1.yaml
+- b1.yaml
+- c1.yaml
+files:
+- d0
+value: 20

--- a/test/d1.yaml
+++ b/test/d1.yaml
@@ -1,0 +1,4 @@
+extends: d0.yaml
+files:
+- d1
+value: 30

--- a/test/settings.yaml
+++ b/test/settings.yaml
@@ -1,0 +1,10 @@
+# settings.yaml
+---
+extends:
+  - 'base.yaml'
+blockX:
+- playground:
+    macros:
+      M_DERIVE: ja
+      M_REPLACE: replaced
+...

--- a/test/test.rb
+++ b/test/test.rb
@@ -1,0 +1,13 @@
+#!/usr/bin/env ruby
+
+require '../lib/yaml_extend.rb'
+
+# no automated check for now
+config=YAML.ext_load_file 'd1.yaml', tree_traversal: :postorder
+expected={'files' => ['a0','a1','b0','b1','c0','c1','d0','d1'], 'value' => 30}
+
+puts "#{config}"
+puts "#{expected}"
+puts "equal=#{config==expected}"
+
+

--- a/test/test.rb
+++ b/test/test.rb
@@ -5,20 +5,30 @@ require '../lib/yaml_extend.rb'
 # no automated check for now
 
 # new scheme
-config=YAML.ext_load_file 'd1.yaml', tree_traversal: :postorder
+files=[]
+config=YAML.ext_load_file 'd1.yaml', files: files, tree_traversal: :postorder
 expected={'files' => ['a0','a1','b0','b1','c0','c1','d0','d1'], 'value' => 30}
-
+puts "files encountered: #{files}"
 puts "#{config}"
 puts "#{expected}"
 puts "equal=#{config==expected}"
-
 # default scheme
-config=YAML.ext_load_file 'd1.yaml'
+files=[]
+config=YAML.ext_load_file 'd1.yaml', files: files
 expected={'files' => ["d1", "d0", "a1", "a0", "b1", "b0", "c1", "c0"], 'value' => 30}
-
+puts "files encountered: #{files}"
 puts "#{config}"
 puts "#{expected}"
 puts "equal=#{config==expected}"
 
+# simple base - derived
+config=YAML.ext_load_file 'settings.yaml'
+puts "config=YAML.ext_load_file 'settings.yaml'"
+pp config
+config=YAML.ext_load_file 'settings.yaml', tree_traversal: :postorder
+puts "config=YAML.ext_load_file 'settings.yaml', tree_traversal: :postorder"
+pp config
+
+# file discovery
 
 

--- a/test/test.rb
+++ b/test/test.rb
@@ -3,11 +3,22 @@
 require '../lib/yaml_extend.rb'
 
 # no automated check for now
+
+# new scheme
 config=YAML.ext_load_file 'd1.yaml', tree_traversal: :postorder
 expected={'files' => ['a0','a1','b0','b1','c0','c1','d0','d1'], 'value' => 30}
 
 puts "#{config}"
 puts "#{expected}"
 puts "equal=#{config==expected}"
+
+# default scheme
+config=YAML.ext_load_file 'd1.yaml'
+expected={'files' => ["d1", "d0", "a1", "a0", "b1", "b0", "c1", "c0"], 'value' => 30}
+
+puts "#{config}"
+puts "#{expected}"
+puts "equal=#{config==expected}"
+
 
 

--- a/yaml_extend.gemspec
+++ b/yaml_extend.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'deep_merge', '~> 1.1'
+  spec.add_dependency 'rubytree', '~> 1.0'
 
   spec.add_development_dependency 'bundler',  '>= 1.14'
   spec.add_development_dependency 'rake',     '>= 10.0'


### PR DESCRIPTION
I added an option to solve #6 
There is now a new option (tree_traversal) which can be set to 
:breadthfirst  --> this is the old behaviour
:postorder    --> new option

In the new option the merging happens in the other direction, i.e. it starts at the most super class, in there it merges the derived, and so forth. Files at the same level, get merged from left to right.
It uses deep_merge! instead of deep_merge.

I used the rubytree class to get a very lean implementation. I think the 'classic' behavior can also be done via this method, but I did not dare changing the working code.

I also made a test directory with some test files that I used to test this setup. There is no automation though...