### PR TITLE
Ensure extending from a non-relative absolute directory works as expected.

### DIFF
--- a/lib/yaml_extend.rb
+++ b/lib/yaml_extend.rb
@@ -66,7 +66,13 @@ module YAML
     if super_inheritance_files && super_inheritance_files != ''
       super_inheritance_files = [super_inheritance_files] unless super_inheritance_files.is_a? Array # we support strings as well as arrays of type string to extend from
       super_inheritance_files.each_with_index do |super_inheritance_file, index|
-        super_config_path = File.dirname(yaml_path) + '/' + super_inheritance_file
+        # Extend a YAML path in an absolute directory
+        if YAML.absolute_path?(super_inheritance_file)
+          super_config_path = YAML.make_absolute_path(super_inheritance_file)
+        # Extend a YAML path in a relative directory
+        else
+          super_config_path = File.dirname(yaml_path) + '/' + super_inheritance_file
+        end
         total_config = YAML.ext_load_file_recursive(super_config_path, inheritance_key, extend_existing_arrays, total_config)
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 require "bundler/setup"
 require "yaml_extend"
+require 'tempfile'
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure

--- a/spec/test_data/ext_load_file_absolute_01.yml
+++ b/spec/test_data/ext_load_file_absolute_01.yml
@@ -1,0 +1,7 @@
+# encoding: utf-8
+---
+first: "foo"
+extends: 
+    - /tmp/ext_load_file_absolute_02.yml
+    - ext_load_file_absolute_03.yml
+

--- a/spec/test_data/ext_load_file_absolute_01.yml.tmpl
+++ b/spec/test_data/ext_load_file_absolute_01.yml.tmpl
@@ -2,6 +2,6 @@
 ---
 first: "foo"
 extends: 
-    - /tmp/ext_load_file_absolute_02.yml
+    - {{absolute_template_path}}
     - ext_load_file_absolute_03.yml
 

--- a/spec/test_data/ext_load_file_absolute_02.yml
+++ b/spec/test_data/ext_load_file_absolute_02.yml
@@ -1,0 +1,4 @@
+# encoding: utf-8
+---
+first: "bar"
+absolute: true

--- a/spec/test_data/ext_load_file_absolute_03.yml
+++ b/spec/test_data/ext_load_file_absolute_03.yml
@@ -1,0 +1,4 @@
+# encoding: utf-8
+---
+first: "cake"
+third: "charm"

--- a/spec/yaml_extend_spec.rb
+++ b/spec/yaml_extend_spec.rb
@@ -45,6 +45,17 @@ RSpec.describe YAML,'#ext_load_file' do
       yaml_obj = YAML.ext_load_file 'test_data/ext_load_file_04.yml'
       expect(yaml_obj).to include('first')
     end
+    it 'extends with another yaml from another absolute directory' do
+      tmp_file = Tempfile.new
+      tmp_file.write(File.read('spec/test_data/ext_load_file_absolute_02.yml'))
+      tmp_file.close
+      expect(tmp_file.path).to start_with('/')
+
+      yaml_obj = YAML.ext_load_file 'test_data/ext_load_file_absolute_01.yml'
+      expect(yaml_obj['first']).to eql('foo')
+      expect(yaml_obj['absolute']).to eql(true)
+      expect(yaml_obj['third']).to eql('charm')
+     end
     it 'extends with another yaml file by using another extend key' do
       yaml_obj = YAML.ext_load_file 'test_data/other_key.yml', 'inherits_from'
       expect(yaml_obj).to include('first')


### PR DESCRIPTION
I'm not quite sure if this is supposed to be supported, as the `yaml_path` can be absolute, but absolute paths for `extends` appear to not be working.

I was attempting to perform something like

```
# encoding: utf-8
---
extends: 
    - "ext_load_file_01.yml"
    - /tmp/ext_load_file_absolute_02.yml
```

Which would always result in the path being prefixed with the `yaml_path`:

```
  1) Psych#ext_load_file Test inheritance feature extends with another yaml file
     Failure/Error: raise error_message

     RuntimeError:
       Can not find absolute path of '/Users/jpaton/data/code/yaml_extend/spec/test_data//tmp/ext_load_file_absolute_02.yml'
```

I have a use case for mixing absolute and relative paths in the `extends` array, so hope this can be considered.