### PR TITLE
Add ERB support

### DIFF
--- a/lib/yaml_extend.rb
+++ b/lib/yaml_extend.rb
@@ -105,7 +105,14 @@ module YAML
     total_config = config.clone
 
     yaml_path = YAML.make_absolute_path yaml_path
-    super_config = YAML.load_file(File.open(yaml_path))
+
+    super_config =
+      if yaml_path.match(/\.erb/)
+        YAML.load(ERB.new(File.read(yaml_path)).result)
+      else
+        YAML.load_file(File.open(yaml_path))
+      end
+
     super_inheritance_files = yaml_value_by_key inheritance_key, super_config
     unless options[:preserve_inheritance_key]
       delete_yaml_key inheritance_key, super_config # we don't merge the super inheritance keys into the base yaml

--- a/lib/yaml_extend.rb
+++ b/lib/yaml_extend.rb
@@ -107,7 +107,7 @@ module YAML
     yaml_path = YAML.make_absolute_path yaml_path
 
     super_config =
-      if yaml_path.match(/\.erb/)
+      if yaml_path.match(/(\.erb\.|\.erb$)/)
         YAML.load(ERB.new(File.read(yaml_path)).result)
       else
         YAML.load_file(File.open(yaml_path))

--- a/spec/test_data/erb_in_yaml/config.erbse.yml
+++ b/spec/test_data/erb_in_yaml/config.erbse.yml
@@ -1,0 +1,3 @@
+# encoding: utf-8
+---
+erbse2: <%= 'DoNot' + 'Render2' %>

--- a/spec/test_data/erb_in_yaml/config.yml.erb
+++ b/spec/test_data/erb_in_yaml/config.yml.erb
@@ -1,4 +1,10 @@
 # encoding: utf-8
 ---
-extends: 'super.yml.erb'
+extends:
+  - 'super.yml.erb'
+  - 'super.erb.yml'
+  - 'config.erbse.yml'
+  - 'config.yml.erbse'
+  - 'config.yml.herb'
+  - 'config.yml.herbs'
 erb: <%= 'Foo' + 'Bar' %>

--- a/spec/test_data/erb_in_yaml/config.yml.erb
+++ b/spec/test_data/erb_in_yaml/config.yml.erb
@@ -1,0 +1,4 @@
+# encoding: utf-8
+---
+extends: 'super.yml.erb'
+erb: <%= 'Foo' + 'Bar' %>

--- a/spec/test_data/erb_in_yaml/config.yml.erbse
+++ b/spec/test_data/erb_in_yaml/config.yml.erbse
@@ -1,0 +1,3 @@
+# encoding: utf-8
+---
+erbse1: <%= 'DoNot' + 'Render1' %>

--- a/spec/test_data/erb_in_yaml/config.yml.herb
+++ b/spec/test_data/erb_in_yaml/config.yml.herb
@@ -1,0 +1,3 @@
+# encoding: utf-8
+---
+herb: <%= 'DoNot' + 'Render3' %>

--- a/spec/test_data/erb_in_yaml/config.yml.herbs
+++ b/spec/test_data/erb_in_yaml/config.yml.herbs
@@ -1,0 +1,3 @@
+# encoding: utf-8
+---
+herbs: <%= 'DoNot' + 'Render4' %>

--- a/spec/test_data/erb_in_yaml/super.erb.yml
+++ b/spec/test_data/erb_in_yaml/super.erb.yml
@@ -1,0 +1,4 @@
+# encoding: utf-8
+---
+different_file_extension_order: <%= true %>
+yaml_erb: <%= 'Yaml' + 'ERB' %>

--- a/spec/test_data/erb_in_yaml/super.yml.erb
+++ b/spec/test_data/erb_in_yaml/super.yml.erb
@@ -1,0 +1,4 @@
+# encoding: utf-8
+---
+super: true
+super_erb: <%= 'Super' + 'Foo' %>

--- a/spec/yaml_extend_spec.rb
+++ b/spec/yaml_extend_spec.rb
@@ -273,10 +273,16 @@ end
 
 RSpec.describe YAML,'#erb_in_yaml' do
   context 'Interprets ERB tags in yaml.erb files' do
-    it 'verifies ERB (String)' do
+    it "verifies ERB (String) in files ending with '.erb' or including '.erb.'' in file name" do
       yaml_obj = YAML.ext_load_file 'test_data/erb_in_yaml/config.yml.erb'
       expect(yaml_obj['erb']).to eql('FooBar')
       expect(yaml_obj['super_erb']).to eql('SuperFoo')
+      expect(yaml_obj['different_file_extension_order']).to eql(true)
+      expect(yaml_obj['yaml_erb']).to eql('YamlERB')
+      expect(yaml_obj['erbse1']).to eql("<%= 'DoNot' + 'Render1' %>")
+      expect(yaml_obj['erbse2']).to eql("<%= 'DoNot' + 'Render2' %>")
+      expect(yaml_obj['herb']).to eql("<%= 'DoNot' + 'Render3' %>")
+      expect(yaml_obj['herbs']).to eql("<%= 'DoNot' + 'Render4' %>")
     end
   end
 end

--- a/spec/yaml_extend_spec.rb
+++ b/spec/yaml_extend_spec.rb
@@ -270,3 +270,13 @@ RSpec.describe YAML,'#ext_load_key=' do
     YAML.reset_load_key
   end
 end
+
+RSpec.describe YAML,'#erb_in_yaml' do
+  context 'Interprets ERB tags in yaml.erb files' do
+    it 'verifies ERB (String)' do
+      yaml_obj = YAML.ext_load_file 'test_data/erb_in_yaml/config.yml.erb'
+      expect(yaml_obj['erb']).to eql('FooBar')
+      expect(yaml_obj['super_erb']).to eql('SuperFoo')
+    end
+  end
+end


### PR DESCRIPTION
Recently started using this gem for a project, but I needed to use ERB tags inside the yaml files and that did not seem to be supported.

Added a conditional to check for the presence of a ".erb" file extension in the `yaml_path` variable. If present, we load the yaml content through the ERB interpreter first. The fact that this check is in the `ext_load_file_recursive` class method means that it checks all files up the chain of extends, so it will convert ERB tags in parent yaml files (with an erb file extension) also.

- check for yml.erb file extension to process yaml with ERB
- add test