### PR TITLE
Adds failing spec for loading YAML with falsey keys

### DIFF
--- a/spec/test_data/falsey_key.yml
+++ b/spec/test_data/falsey_key.yml
@@ -1,0 +1,5 @@
+# encoding: utf-8
+---
+false: "San Pellegrino"
+nil: "Fanta"
+no: "Gerolsteiner"

--- a/spec/yaml_extend_spec.rb
+++ b/spec/yaml_extend_spec.rb
@@ -9,6 +9,13 @@ end
 RSpec.describe YAML,'#ext_load_file' do
   context 'Test inheritance feature' do
 
+    it 'retains falsey input keys' do
+      yaml_obj = YAML.ext_load_file 'test_data/falsey_key.yml'
+
+      expect(yaml_obj['false']).to eql('San Pellegrino')
+      expect(yaml_obj['nil']).to eql('Fanta')
+      expect(yaml_obj['no']).to eql('Gerolsteiner')
+    end
     it 'respects multi-file inheritance precedence order' do
       yaml_obj = YAML.ext_load_file 'test_data/overwrite_multiple_files/child.yml'
 


### PR DESCRIPTION
This is a WIP PR to demonstrate what I believe is unintended change when calling `ext_load_file`. I would like confirmation this is a bug, and a pointer on where to fix it before proceeding.

The `yaml_obj` from the spec that loads `falsey_key.yml` is:

```
{false=>"Gerolsteiner", "nil"=>"Fanta"}
```