### PR TITLE
Show behavior of merge hash array for overwrite issue

### DIFF
--- a/spec/test_data/merge_hash_array_overwrite/child.yml
+++ b/spec/test_data/merge_hash_array_overwrite/child.yml
@@ -1,3 +1,5 @@
 extends: parent.yml
-traits:
-- name: happy
+dog:
+  - breed: golden
+    traits:
+    - name: happy

--- a/spec/test_data/merge_hash_array_overwrite/child.yml
+++ b/spec/test_data/merge_hash_array_overwrite/child.yml
@@ -1,0 +1,5 @@
+extends: parent.yml
+dog:
+- breed: lab
+  traits:
+  - name: happy

--- a/spec/test_data/merge_hash_array_overwrite/child.yml
+++ b/spec/test_data/merge_hash_array_overwrite/child.yml
@@ -1,5 +1,3 @@
 extends: parent.yml
-dog:
-- breed: lab
-  traits:
-  - name: happy
+traits:
+- name: happy

--- a/spec/test_data/merge_hash_array_overwrite/expected.yaml
+++ b/spec/test_data/merge_hash_array_overwrite/expected.yaml
@@ -1,7 +1,5 @@
-dog:
-- breed: lab
-  traits:
-  - name: friendly
-  - name: happy
-  - name: smart
-  - name: strong
+traits:
+- name: friendly
+- name: happy
+- name: smart
+- name: strong

--- a/spec/test_data/merge_hash_array_overwrite/expected.yaml
+++ b/spec/test_data/merge_hash_array_overwrite/expected.yaml
@@ -1,5 +1,7 @@
-traits:
-- name: friendly
-- name: happy
-- name: smart
-- name: strong
+dog:
+  - breed: golden
+    traits:
+    - name: friendly
+    - name: happy
+    - name: smart
+    - name: strong

--- a/spec/test_data/merge_hash_array_overwrite/expected.yaml
+++ b/spec/test_data/merge_hash_array_overwrite/expected.yaml
@@ -1,0 +1,7 @@
+dog:
+- breed: lab
+  traits:
+  - name: friendly
+  - name: happy
+  - name: smart
+  - name: strong

--- a/spec/test_data/merge_hash_array_overwrite/parent.yml
+++ b/spec/test_data/merge_hash_array_overwrite/parent.yml
@@ -1,4 +1,6 @@
-traits:
-- name: friendly
-- name: smart
-- name: strong
+dog:
+  - breed: golden
+    traits:
+    - name: friendly
+    - name: smart
+    - name: strong

--- a/spec/test_data/merge_hash_array_overwrite/parent.yml
+++ b/spec/test_data/merge_hash_array_overwrite/parent.yml
@@ -1,7 +1,4 @@
-dog:
-- breed: lab
-  name: Fido
-  traits:
-  - name: friendly
-  - name: smart
-  - name: strong
+traits:
+- name: friendly
+- name: smart
+- name: strong

--- a/spec/test_data/merge_hash_array_overwrite/parent.yml
+++ b/spec/test_data/merge_hash_array_overwrite/parent.yml
@@ -1,0 +1,7 @@
+dog:
+- breed: lab
+  name: Fido
+  traits:
+  - name: friendly
+  - name: smart
+  - name: strong

--- a/spec/yaml_extend_spec.rb
+++ b/spec/yaml_extend_spec.rb
@@ -175,7 +175,7 @@ RSpec.describe YAML,'#ext_load_file' do
     end
     it 'does merge hash arrays if parameter true in options hash' do
       yaml_obj = YAML.ext_load_file 'spec/test_data/merge_hash_array_overwrite/child.yml', nil, { merge_hash_arrays: true }
-      trait_values = yaml_obj['dog'][0]['traits'].map do |trait|
+      trait_values = yaml_obj['traits'].map do |trait|
         trait['name']
       end
       expect(trait_values).to match_array(['friendly', 'happy', 'smart', 'strong'])

--- a/spec/yaml_extend_spec.rb
+++ b/spec/yaml_extend_spec.rb
@@ -173,6 +173,13 @@ RSpec.describe YAML,'#ext_load_file' do
       expect(yaml_obj['fruits']).to include('Grapefruit')
       expect(yaml_obj['fruits']).not_to include('Banana','Orange')
     end
+    it 'does merge hash arrays if parameter true in options hash' do
+      yaml_obj = YAML.ext_load_file 'spec/test_data/merge_hash_array_overwrite/child.yml', nil, { merge_hash_arrays: true }
+      trait_values = yaml_obj['dog'][0]['traits'].map do |trait|
+        trait['name']
+      end
+      expect(trait_values).to match_array(['friendly', 'happy', 'smart', 'strong'])
+    end
     it 'does not delete inheritance key if option is set to false' do
       yaml_obj = YAML.ext_load_file 'test_data/option_extend_existing_array/child.yml', nil, { preserve_inheritance_key: true }
       expect(yaml_obj).to include('extends')

--- a/spec/yaml_extend_spec.rb
+++ b/spec/yaml_extend_spec.rb
@@ -174,8 +174,8 @@ RSpec.describe YAML,'#ext_load_file' do
       expect(yaml_obj['fruits']).not_to include('Banana','Orange')
     end
     it 'does merge hash arrays if parameter true in options hash' do
-      yaml_obj = YAML.ext_load_file 'spec/test_data/merge_hash_array_overwrite/child.yml', nil, { merge_hash_arrays: true }
-      trait_values = yaml_obj['traits'].map do |trait|
+     yaml_obj = YAML.ext_load_file 'spec/test_data/merge_hash_array_overwrite/child.yml', nil, { merge_hash_arrays: true }
+      trait_values = yaml_obj['dog'][0]['traits'].map do |trait|
         trait['name']
       end
       expect(trait_values).to match_array(['friendly', 'happy', 'smart', 'strong'])


### PR DESCRIPTION
This is a WIP MR to showcase a question regarding the behavior of the `merge hash array` option. 

The issue I am running into is that when trying to merge nested arrays within nested hashes, the array gets over-written. 
For instance when merging the parent and child yaml files below the behavior that I want to achieve is the addition of the happy trait without overwriting any traits, however the actual behavior is that the the friendly trait is overwritten and replaced. This behavior is showcased in the failing test written.

Is this expected behavior for the gem? and if so is there a way to merge the two together in a way that does not overwrite the traits.

Upon further digging, it is likely that this behavior is the result of the deep_merge gem, I created an issue documenting it there as well 
https://github.com/danielsdeleo/deep_merge/issues/46