### PR TITLE
require erb added to support erb templating

### DIFF
--- a/lib/yaml_extend.rb
+++ b/lib/yaml_extend.rb
@@ -1,6 +1,7 @@
 require 'yaml_extend/version'
 
 require 'yaml'
+require 'erb'
 require 'deep_merge/rails_compat'
 
 require_relative 'custom_errors/invalid_key_type_error'


### PR DESCRIPTION
require 'erb' added to support erb templating

I was getting an error:
lib/yaml_extend.rb:115:in `ext_load_file_recursive': uninitialized constant Psych::ERB (NameError) 

When trying to use the command line version of yaml_extend with an file that had an erb extension
