### PR TITLE
Ability to force ERB preformatting via option

### DIFF
--- a/lib/yaml_extend.rb
+++ b/lib/yaml_extend.rb
@@ -99,6 +99,7 @@ module YAML
       extend_existing_arrays: true,
       merge_nil_values: false,
       merge_debug: false,
+      assume_erb: false,
     }
     options = default_options.merge options
     private_class_method
@@ -110,7 +111,7 @@ module YAML
     yaml_path = YAML.make_absolute_path yaml_path
 
     super_config =
-      if yaml_path.match(/(\.erb\.|\.erb$)/)
+      if options[:assume_erb] || yaml_path.match(/(\.erb\.|\.erb$)/)
         if YAML.respond_to? :unsafe_load # backward compatibility for Ruby 3.1 / Psych 4
           YAML.unsafe_load(ERB.new(File.read(yaml_path)).result)
         else

--- a/spec/test_data/erb_in_yaml/config_with_erb.yml
+++ b/spec/test_data/erb_in_yaml/config_with_erb.yml
@@ -1,0 +1,10 @@
+# encoding: utf-8
+---
+extends:
+  - 'super.yml.erb'
+  - 'super.erb.yml'
+  - 'config.erbse.yml'
+  - 'config.yml.erbse'
+  - 'config.yml.herb'
+  - 'config.yml.herbs'
+erb: <%= 'Foo' + 'Bar' %>

--- a/spec/yaml_extend_spec.rb
+++ b/spec/yaml_extend_spec.rb
@@ -287,6 +287,22 @@ RSpec.describe YAML,'#erb_in_yaml' do
   end
 end
 
+RSpec.describe YAML,'#force_erb_in_yaml' do
+  context 'Interprets ERB when option says so' do
+    it 'verifies ERB (String)' do
+      yaml_obj = YAML.ext_load_file 'test_data/erb_in_yaml/config_with_erb.yml', nil, assume_erb: true
+      expect(yaml_obj['erb']).to eql('FooBar')
+      expect(yaml_obj['super_erb']).to eql('SuperFoo')
+      expect(yaml_obj['different_file_extension_order']).to eql(true)
+      expect(yaml_obj['yaml_erb']).to eql('YamlERB')
+      expect(yaml_obj['erbse1']).to eql('DoNotRender1')
+      expect(yaml_obj['erbse2']).to eql('DoNotRender2')
+      expect(yaml_obj['herb']).to eql('DoNotRender3')
+      expect(yaml_obj['herbs']).to eql('DoNotRender4')
+    end
+  end
+end
+
 RSpec.describe YAML,'using aliases (ruby 3.1 and psych 4 compatibility)' do
   context 'Can handle aliases' do
     it 'handles aliases in yml file' do


### PR DESCRIPTION
In YAML configuration files, sometimes ERB preformatting happens even without any "erb" in the filename.
For those files, ERB preformatting is implicitly enabled from the beginning, you don't have to rename your config.yml to enable it (to config.erb.yml or config.yml.erb).

This very simple commit adds an option to `ext_load_file` for considering all input files as ERB, disregarding their filenames:  `assume_erb: true`
(Feel free to change the name of the option)

Test included.